### PR TITLE
Allow get access to LazyOptionals in ICapabilityHolder components

### DIFF
--- a/src/main/java/com/hrznstudio/titanium/block/tile/ActiveTile.java
+++ b/src/main/java/com/hrznstudio/titanium/block/tile/ActiveTile.java
@@ -53,8 +53,6 @@ import net.minecraft.util.text.Style;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraft.util.text.TranslationTextComponent;
 import net.minecraft.world.World;
-import net.minecraft.world.server.ServerWorld;
-import net.minecraft.world.storage.IServerWorldInfo;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.fluids.FluidUtil;

--- a/src/main/java/com/hrznstudio/titanium/block/tile/ActiveTile.java
+++ b/src/main/java/com/hrznstudio/titanium/block/tile/ActiveTile.java
@@ -53,6 +53,8 @@ import net.minecraft.util.text.Style;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraft.util.text.TranslationTextComponent;
 import net.minecraft.world.World;
+import net.minecraft.world.server.ServerWorld;
+import net.minecraft.world.storage.IServerWorldInfo;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.fluids.FluidUtil;
@@ -353,4 +355,10 @@ public abstract class ActiveTile<T extends ActiveTile<T>> extends BasicTile<T> i
         return this.getWorld() != null ? IWorldPosCallable.of(this.getWorld(), this.getPos()) : IWorldPosCallable.DUMMY;
     }
 
+    @Override
+    public void invalidateCaps() {
+        super.invalidateCaps();
+        this.multiInventoryComponent.getLazyOptionals().forEach(LazyOptional::invalidate);
+        this.multiTankComponent.getLazyOptionals().forEach(LazyOptional::invalidate);
+    }
 }

--- a/src/main/java/com/hrznstudio/titanium/component/fluid/MultiTankComponent.java
+++ b/src/main/java/com/hrznstudio/titanium/component/fluid/MultiTankComponent.java
@@ -96,6 +96,11 @@ public class MultiTankComponent<T extends IComponentHarness> implements IScreenA
         return false;
     }
 
+    @Override
+    public Collection<LazyOptional<MultiTankCapabilityHandler<T>>> getLazyOptionals() {
+        return this.lazyOptionals.values();
+    }
+
     public HashSet<FluidTankComponent<T>> getTanks() {
         return tanks;
     }

--- a/src/main/java/com/hrznstudio/titanium/component/inventory/MultiInventoryComponent.java
+++ b/src/main/java/com/hrznstudio/titanium/component/inventory/MultiInventoryComponent.java
@@ -44,7 +44,6 @@ public class MultiInventoryComponent<T extends IComponentHarness> implements ISc
     public void add(Object... component) {
         Arrays.stream(component).filter(this::accepts).forEach(inventoryComponent -> {
             this.inventoryHandlers.add((InventoryComponent<T>) inventoryComponent);
-            rebuildCapability(new FacingUtil.Sideness[]{null});
             rebuildCapability(FacingUtil.Sideness.values());
         });
     }

--- a/src/main/java/com/hrznstudio/titanium/component/inventory/MultiInventoryComponent.java
+++ b/src/main/java/com/hrznstudio/titanium/component/inventory/MultiInventoryComponent.java
@@ -213,4 +213,9 @@ public class MultiInventoryComponent<T extends IComponentHarness> implements ISc
             return 0;
         }
     }
+
+    @Override
+    public Collection<LazyOptional<MultiInvCapabilityHandler<T>>> getLazyOptionals() {
+        return lazyOptionals.values();
+    }
 }

--- a/src/main/java/com/hrznstudio/titanium/component/sideness/ICapabilityHolder.java
+++ b/src/main/java/com/hrznstudio/titanium/component/sideness/ICapabilityHolder.java
@@ -12,6 +12,7 @@ import net.minecraftforge.common.util.LazyOptional;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Collection;
 
 public interface ICapabilityHolder<T> {
 
@@ -19,4 +20,6 @@ public interface ICapabilityHolder<T> {
     LazyOptional<T> getCapabilityForSide(@Nullable FacingUtil.Sideness sideness);
 
     boolean handleFacingChange(String handlerName, FacingUtil.Sideness facing, IFacingComponent.FaceMode mode);
+
+    Collection<LazyOptional<T>> getLazyOptionals();
 }


### PR DESCRIPTION
I want to be able to do this:
`this.multiInventoryComponent.getLazyOptionals().forEach(o -> o.invalidate());` `this.multiTankComponent.getLazyOptionals().forEach(o -> o.invalidate());`

Where necessary (when invalidateCaps is called from my tile) to neatly invalidate all of my machine capabilities. Out of curiosity, how does stuff that depends on ActiveTile handle this? Manually?  