### PR TITLE
Fix a variety of issues related to teleporting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -102,7 +102,7 @@ repositories {
      }
 }
 dependencies {
-  minecraft 'net.minecraftforge:forge:1.16.5-36.0.1'
+  minecraft 'net.minecraftforge:forge:1.16.5-36.2.8'
 
   compileOnly fg.deobf("mezz.jei:jei-1.16.5:7.7.1.121:api")
         // at runtime, use the full JEI jar

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-7.2-20210702220150+0000-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -1,3 +1,19 @@
+@rem
+@rem Copyright 2015 the original author or authors.
+@rem
+@rem Licensed under the Apache License, Version 2.0 (the "License");
+@rem you may not use this file except in compliance with the License.
+@rem You may obtain a copy of the License at
+@rem
+@rem      https://www.apache.org/licenses/LICENSE-2.0
+@rem
+@rem Unless required by applicable law or agreed to in writing, software
+@rem distributed under the License is distributed on an "AS IS" BASIS,
+@rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+@rem See the License for the specific language governing permissions and
+@rem limitations under the License.
+@rem
+
 @if "%DEBUG%" == "" @echo off
 @rem ##########################################################################
 @rem
@@ -8,20 +24,23 @@
 @rem Set local scope for the variables with windows NT shell
 if "%OS%"=="Windows_NT" setlocal
 
-@rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-set DEFAULT_JVM_OPTS=
-
 set DIRNAME=%~dp0
 if "%DIRNAME%" == "" set DIRNAME=.
 set APP_BASE_NAME=%~n0
 set APP_HOME=%DIRNAME%
+
+@rem Resolve any "." and ".." in APP_HOME to make it shorter.
+for %%i in ("%APP_HOME%") do set APP_HOME=%%~fi
+
+@rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+set DEFAULT_JVM_OPTS="-Xmx64m" "-Xms64m"
 
 @rem Find java.exe
 if defined JAVA_HOME goto findJavaFromJavaHome
 
 set JAVA_EXE=java.exe
 %JAVA_EXE% -version >NUL 2>&1
-if "%ERRORLEVEL%" == "0" goto init
+if "%ERRORLEVEL%" == "0" goto execute
 
 echo.
 echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
@@ -35,7 +54,7 @@ goto fail
 set JAVA_HOME=%JAVA_HOME:"=%
 set JAVA_EXE=%JAVA_HOME%/bin/java.exe
 
-if exist "%JAVA_EXE%" goto init
+if exist "%JAVA_EXE%" goto execute
 
 echo.
 echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME%
@@ -45,34 +64,14 @@ echo location of your Java installation.
 
 goto fail
 
-:init
-@rem Get command-line arguments, handling Windowz variants
-
-if not "%OS%" == "Windows_NT" goto win9xME_args
-if "%@eval[2+2]" == "4" goto 4NT_args
-
-:win9xME_args
-@rem Slurp the command line arguments.
-set CMD_LINE_ARGS=
-set _SKIP=2
-
-:win9xME_args_slurp
-if "x%~1" == "x" goto execute
-
-set CMD_LINE_ARGS=%*
-goto execute
-
-:4NT_args
-@rem Get arguments from the 4NT Shell from JP Software
-set CMD_LINE_ARGS=%$
-
 :execute
 @rem Setup the command line
 
 set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
 
+
 @rem Execute Gradle
-"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %CMD_LINE_ARGS%
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %*
 
 :end
 @rem End local scope for the variables with windows NT shell

--- a/src/main/java/com/hrznstudio/titanium/util/TeleportationUtils.java
+++ b/src/main/java/com/hrznstudio/titanium/util/TeleportationUtils.java
@@ -9,6 +9,8 @@ package com.hrznstudio.titanium.util;
 
 import net.minecraft.block.PortalInfo;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.ServerPlayerEntity;
+import net.minecraft.network.play.server.SMoveVehiclePacket;
 import net.minecraft.network.play.server.SSetPassengersPacket;
 import net.minecraft.util.RegistryKey;
 import net.minecraft.util.math.BlockPos;
@@ -16,10 +18,12 @@ import net.minecraft.util.math.vector.Vector3d;
 import net.minecraft.world.World;
 import net.minecraft.world.server.ServerChunkProvider;
 import net.minecraft.world.server.ServerWorld;
+import net.minecraftforge.common.util.FakePlayer;
 import net.minecraftforge.common.util.ITeleporter;
 
 import java.util.List;
 import java.util.function.Function;
+import net.minecraftforge.entity.PartEntity;
 
 public class TeleportationUtils {
 
@@ -29,6 +33,10 @@ public class TeleportationUtils {
     }
 
     public static Entity teleportEntityTo(Entity entity, BlockPos target, RegistryKey<World> destinationDimension, float yaw, float pitch) {
+        if (entity instanceof PartEntity) {
+            //Don't allow teleporting sub parts of an entity (such as an ender dragon's wing)
+            return entity;
+        }
         if (entity.getEntityWorld().getDimensionKey() == destinationDimension) {
             entity.rotationYaw = yaw;
             entity.rotationPitch = pitch;
@@ -37,9 +45,20 @@ public class TeleportationUtils {
             if (!entity.getPassengers().isEmpty()) {
                 //Force re-apply any passengers so that players don't get "stuck" outside what they may be riding
                 ((ServerChunkProvider) entity.getEntityWorld().getChunkProvider()).sendToAllTracking(entity, new SSetPassengersPacket(entity));
+                Entity controller = entity.getControllingPassenger();
+                if (controller != entity && controller instanceof ServerPlayerEntity && !(controller instanceof FakePlayer)) {
+                    ServerPlayerEntity player = (ServerPlayerEntity) controller;
+                    if (player.connection != null) {
+                        //Force sync the fact that the vehicle moved to the client that is controlling it
+                        // so that it makes sure to use the correct positions when sending move packets
+                        // back to the server instead of running into moved wrongly issues
+                        player.connection.sendPacket(new SMoveVehiclePacket(entity));
+                    }
+                }
             }
             return entity;
-        } else {
+        } else if (entity.isNonBoss()) {
+            //If the entity can change dimensions, try finding the destination world to teleport it to
             ServerWorld newWorld = ((ServerWorld) entity.getEntityWorld()).getServer().getWorld(destinationDimension);
             if (newWorld != null) {
                 Vector3d destination = new Vector3d(target.getX() + 0.5, target.getY(), target.getZ() + 0.5);
@@ -52,7 +71,7 @@ public class TeleportationUtils {
                         if (repositionedEntity != null) {
                             //Teleport all passengers to the other dimension and then make them start riding the entity again
                             for (Entity passenger : passengers) {
-                                teleportPassenger(destWorld, repositionedEntity, passenger);
+                                teleportPassenger(destWorld, destination, repositionedEntity, passenger);
                             }
                         }
                         return repositionedEntity;
@@ -62,28 +81,55 @@ public class TeleportationUtils {
                     public PortalInfo getPortalInfo(Entity entity, ServerWorld destWorld, Function<ServerWorld, PortalInfo> defaultPortalInfo) {
                         return new PortalInfo(destination, entity.getMotion(), yaw, pitch);
                     }
+
+                    @Override
+                    public boolean playTeleportSound(ServerPlayerEntity player, ServerWorld sourceWorld, ServerWorld destWorld) {
+                        return false;
+                    }
                 });
             }
         }
-        return null;
+        //Fall back to returning the source entity without it having teleported
+        return entity;
     }
 
-    private static void teleportPassenger(ServerWorld destWorld, Entity repositionedEntity, Entity passenger) {
+    private static void teleportPassenger(ServerWorld destWorld, Vector3d destination, Entity repositionedEntity, Entity passenger) {
+        if (!passenger.isNonBoss()) {
+            //If the passenger can't change dimensions just let it peacefully stay after dismounting rather than trying to teleport it
+            return;
+        }
         //Note: We grab the passengers here instead of in placeEntity as changeDimension starts by removing any passengers
         List<Entity> passengers = passenger.getPassengers();
         passenger.changeDimension(destWorld, new ITeleporter() {
             @Override
             public Entity placeEntity(Entity entity, ServerWorld currentWorld, ServerWorld destWorld, float yaw, Function<Boolean, Entity> repositionEntity) {
+                boolean invulnerable = entity.isInvulnerable();
+                //Make the entity invulnerable so that when we teleport it, it doesn't take damage
+                // we revert this state to the previous state after teleporting
+                entity.setInvulnerable(true);
                 Entity repositionedPassenger = repositionEntity.apply(false);
                 if (repositionedPassenger != null) {
                     //Force our passenger to start riding the new entity again
                     repositionedPassenger.startRiding(repositionedEntity, true);
                     //Teleport "nested" passengers
                     for (Entity passenger : passengers) {
-                        teleportPassenger(destWorld, repositionedPassenger, passenger);
+                        teleportPassenger(destWorld, destination, repositionedPassenger, passenger);
                     }
+                    repositionedPassenger.setInvulnerable(invulnerable);
                 }
+                entity.setInvulnerable(invulnerable);
                 return repositionedPassenger;
+            }
+
+            @Override
+            public PortalInfo getPortalInfo(Entity entity, ServerWorld destWorld, Function<ServerWorld, PortalInfo> defaultPortalInfo) {
+                //This is needed to ensure the passenger starts getting tracked after teleporting
+                return new PortalInfo(destination, entity.getMotion(), entity.rotationYaw, entity.rotationPitch);
+            }
+
+            @Override
+            public boolean playTeleportSound(ServerPlayerEntity player, ServerWorld sourceWorld, ServerWorld destWorld) {
+                return false;
             }
         });
     }

--- a/src/main/java/com/hrznstudio/titanium/util/TeleportationUtils.java
+++ b/src/main/java/com/hrznstudio/titanium/util/TeleportationUtils.java
@@ -32,6 +32,15 @@ public class TeleportationUtils {
         return teleportEntityTo(entity, new BlockPos(xCoord, yCoord, zCoord), dimension, yaw ,pitch);
     }
 
+    /**
+     * From Mekanism (MIT licensed) TileEntityTeleporter#teleportEntityTo with a couple minor validation and direction tweaks.
+     * @param entity               Entity to teleport.
+     * @param target               Target position.
+     * @param destinationDimension Target dimension.
+     * @param yaw                  Yaw the entity will have after teleporting.
+     * @param pitch                Pitch the entity will have after teleporting.
+     * @return The entity that teleported.
+     */
     public static Entity teleportEntityTo(Entity entity, BlockPos target, RegistryKey<World> destinationDimension, float yaw, float pitch) {
         if (entity instanceof PartEntity) {
             //Don't allow teleporting sub parts of an entity (such as an ender dragon's wing)
@@ -93,6 +102,13 @@ public class TeleportationUtils {
         return entity;
     }
 
+    /**
+     * From Mekanism (MIT licensed) TileEntityTeleporter#teleportPassenger
+     * @param destWorld          Destination world.
+     * @param destination        Destination position.
+     * @param repositionedEntity "New" parent to become a passenger of after teleportation.
+     * @param passenger          Passenger to teleport.
+     */
     private static void teleportPassenger(ServerWorld destWorld, Vector3d destination, Entity repositionedEntity, Entity passenger) {
         if (!passenger.isNonBoss()) {
             //If the passenger can't change dimensions just let it peacefully stay after dismounting rather than trying to teleport it

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -29,6 +29,6 @@ A Lib
 [[dependencies.titanium]] #optional
 modId = "forge" #mandatory
 mandatory = true #mandatory
-versionRange = "[32.0.98,)" #mandatory
+versionRange = "[36.0.62,)" #mandatory
 ordering = "NONE"
 side = "BOTH"


### PR DESCRIPTION
- Fixed teleportation bugging out if a player is riding an entity it has control of (such as a boat)
- Disable vanilla's teleport sound when changing dimensions (portality and such use its own one)
- Don't allow teleporting part entities (for example the wing of an ender dragon, teleporting the dragon will automatically teleport the rest of the entity)
- Respect vanilla's method to check if an entity change dimension (isNonBoss is the MCP name)
- Make passengers have a mostly correct portal info so that entities/players near the destination actually start tracking the entity. Also, briefly make the passenger invulnerable until they are remounted as this may end up causing them to clip into a wall and suffocate
- Bump min forge version to 36.0.62 (needed for disabling teleport sound), bump in dev forge version to 36.2.8
- Update gradle to 7.2 from a 7.2 snapshot as the snapshot that it points at doesn't exist anymore.