### PR TITLE
AlmostUnified integration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,14 +84,12 @@ minecraft {
 repositories {
   mavenCentral()
   maven {
-    // location of the maven that hosts JEI files
-    name = "Progwml6 maven"
-    url = "https://dvs1.progwml6.com/files/maven/"
-  }
-  maven {
-    // location of a maven mirror for JEI files, as a fallback
-    name = "ModMaven"
-    url = "https://modmaven.k-4u.nl"
+    // location for JEI and Almost Unified
+    url = 'https://maven.blamejared.com/'
+    content {
+      includeGroup "mezz.jei"
+      includeGroup "com.almostreliable.mods"
+    }
   }
   maven {
     url "https://maven.tterrag.com/"
@@ -108,6 +106,8 @@ dependencies {
   compileOnly fg.deobf("mezz.jei:jei-1.19.1-forge-api:11.2.0.241")
   // at runtime, use the full JEI jar for Forge
   runtimeOnly fg.deobf("mezz.jei:jei-1.19.1-forge:11.2.0.241")
+  // Almost Unified for compile time
+  compileOnly fg.deobf("com.almostreliable.mods:almostunified-forge:1.19.2-0.3.4")
 }
 
 jar {

--- a/src/main/java/com/hrznstudio/titanium/compat/almostunified/AlmostUnifiedAdapter.java
+++ b/src/main/java/com/hrznstudio/titanium/compat/almostunified/AlmostUnifiedAdapter.java
@@ -1,0 +1,30 @@
+package com.hrznstudio.titanium.compat.almostunified;
+
+import com.almostreliable.unified.api.AlmostUnifiedLookup;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.item.Item;
+import net.minecraftforge.fml.ModList;
+
+import javax.annotation.Nullable;
+
+public class AlmostUnifiedAdapter {
+
+    public static boolean isLoaded() {
+        return ModList.get().isLoaded("almostunified");
+    }
+
+    @Nullable
+    public static Item getPreferredItemForTag(TagKey<Item> tagKey) {
+        if (isLoaded()) {
+            return Adapter.getPreferredItemForTag(tagKey);
+        }
+
+        return null;
+    }
+
+    private static class Adapter {
+        private static Item getPreferredItemForTag(TagKey<Item> tag) {
+            return AlmostUnifiedLookup.INSTANCE.getPreferredItemForTag(tag);
+        }
+    }
+}

--- a/src/main/java/com/hrznstudio/titanium/util/TagUtil.java
+++ b/src/main/java/com/hrznstudio/titanium/util/TagUtil.java
@@ -8,6 +8,7 @@
 package com.hrznstudio.titanium.util;
 
 import com.hrznstudio.titanium._impl.TagConfig;
+import com.hrznstudio.titanium.compat.almostunified.AlmostUnifiedAdapter;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.entity.EntityType;
@@ -108,7 +109,12 @@ public class TagUtil {
 
     }
 
-    public static ItemStack getItemWithPreference(TagKey<Item> tagKey){
+    public static ItemStack getItemWithPreference(TagKey<Item> tagKey) {
+        Item preferredItem = AlmostUnifiedAdapter.getPreferredItemForTag(tagKey);
+        if (preferredItem != null) {
+            return new ItemStack(preferredItem);
+        }
+
         ITag<Item> item = ForgeRegistries.ITEMS.tags().getTag(tagKey);
         if (item.isEmpty()) return ItemStack.EMPTY;
         List<Item> elements = item.stream().toList();


### PR DESCRIPTION
This PR introduces integration for Almost Unified.

It is loaded as a compile-only dependency. The `AlmostUnifiedAdapter` makes sure the mod is actually loaded before accessing internals within the nested class to avoid a crash.

When the mod isn't installed or the API returned no result (`null`), it will use the previous behavior of the library.

The JEI maven was updated too because they switched Mavens and host all their artifacts on Blamejared now. This avoids having 3 Mavens because Almost Unified is hosted there as well.