### PR TITLE
Fix milk bucket duplication

### DIFF
--- a/src/main/java/com/hrznstudio/titanium/block/tile/ActiveTile.java
+++ b/src/main/java/com/hrznstudio/titanium/block/tile/ActiveTile.java
@@ -50,7 +50,9 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.ContainerLevelAccess;
 import net.minecraft.world.item.BucketItem;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.MilkBucketItem;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntityType;
@@ -286,12 +288,15 @@ public abstract class ActiveTile<T extends ActiveTile<T>> extends BasicTile<T> i
                     for (FluidTankComponent<T> fluidTankComponent : multiTankComponent.getTanks()) {
                         if (fluidTankComponent.getName().equalsIgnoreCase(name))
                             Optional.ofNullable(playerEntity.containerMenu.getCarried().getCapability(Capabilities.FluidHandler.ITEM)).ifPresent(iFluidHandlerItem -> {
+                                Item carriedItem = playerEntity.containerMenu.getCarried().getItem();
+                                boolean isBucket = carriedItem instanceof BucketItem || carriedItem instanceof MilkBucketItem;
+
                                 if (fill) {
-                                    int amount = playerEntity.containerMenu.getCarried().getItem() instanceof BucketItem ? FluidType.BUCKET_VOLUME : Integer.MAX_VALUE;
+                                    int amount = isBucket ? FluidType.BUCKET_VOLUME : Integer.MAX_VALUE;
                                     amount = fluidTankComponent.fill(iFluidHandlerItem.drain(amount, IFluidHandler.FluidAction.SIMULATE), IFluidHandler.FluidAction.EXECUTE);
                                     iFluidHandlerItem.drain(amount, IFluidHandler.FluidAction.EXECUTE);
                                 } else {
-                                    int amount = playerEntity.containerMenu.getCarried().getItem() instanceof BucketItem ? FluidType.BUCKET_VOLUME : Integer.MAX_VALUE;
+                                    int amount = isBucket ? FluidType.BUCKET_VOLUME : Integer.MAX_VALUE;
                                     amount = iFluidHandlerItem.fill(fluidTankComponent.drain(amount, IFluidHandler.FluidAction.SIMULATE), IFluidHandler.FluidAction.EXECUTE);
                                     fluidTankComponent.drain(amount, IFluidHandler.FluidAction.EXECUTE);
                                 }

--- a/src/main/java/com/hrznstudio/titanium/client/screen/addon/TankScreenAddon.java
+++ b/src/main/java/com/hrznstudio/titanium/client/screen/addon/TankScreenAddon.java
@@ -32,6 +32,8 @@ import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.item.BucketItem;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.MilkBucketItem;
 import net.neoforged.neoforge.capabilities.Capabilities;
 import net.neoforged.neoforge.client.extensions.common.IClientFluidTypeExtensions;
 import net.neoforged.neoforge.common.Tags;
@@ -107,7 +109,8 @@ public class TankScreenAddon extends BasicScreenAddon {
         strings.add(Component.translatable("tooltip.titanium.tank.amount").withStyle(ChatFormatting.GOLD).append(Component.literal(ChatFormatting.WHITE + new DecimalFormat().format(tank.getFluidAmount()) + ChatFormatting.GOLD + "/" + ChatFormatting.WHITE + new DecimalFormat().format(tank.getCapacity()) + ChatFormatting.DARK_AQUA + "mb")));
         if (!Minecraft.getInstance().player.containerMenu.getCarried().isEmpty() && Minecraft.getInstance().player.containerMenu.getCarried().getCapability(Capabilities.FluidHandler.ITEM) != null) {
             Optional.ofNullable(Minecraft.getInstance().player.containerMenu.getCarried().getCapability(Capabilities.FluidHandler.ITEM)).ifPresent(iFluidHandlerItem -> {
-                boolean isBucket = Minecraft.getInstance().player.containerMenu.getCarried().getItem() instanceof BucketItem;
+                Item carriedItem = Minecraft.getInstance().player.containerMenu.getCarried().getItem();
+                boolean isBucket = carriedItem instanceof BucketItem || carriedItem instanceof MilkBucketItem;
                 int amount = isBucket ? FluidType.BUCKET_VOLUME : Integer.MAX_VALUE;
                 boolean canFillFromItem = false;
                 boolean canDrainFromItem = false;
@@ -162,7 +165,8 @@ public class TankScreenAddon extends BasicScreenAddon {
                     compoundNBT.putBoolean("Invalid", true);
                 }
                 Optional.ofNullable(Minecraft.getInstance().player.containerMenu.getCarried().getCapability(Capabilities.FluidHandler.ITEM)).ifPresent(iFluidHandlerItem -> {
-                    boolean isBucket = Minecraft.getInstance().player.containerMenu.getCarried().getItem() instanceof BucketItem;
+                    Item carriedItem = Minecraft.getInstance().player.containerMenu.getCarried().getItem();
+                    boolean isBucket = carriedItem instanceof BucketItem || carriedItem instanceof MilkBucketItem;
                     int amount = isBucket ? FluidType.BUCKET_VOLUME : Integer.MAX_VALUE;
                     boolean canFillFromItem = false;
                     boolean canDrainFromItem = false;


### PR DESCRIPTION
Resolves: https://github.com/Buuz135/SushiGoCrafting/issues/43

It was possible to duplicate Milk in Tank GUI slots because they were checking for `BucketItem` and not `MilkBucketItem` too.

This PR can be backported to previous Titanium versions if you'd like.