### PR TITLE
Bug-Fixes related to machines.

### DIFF
--- a/src/main/java/com/hrznstudio/titanium/block/redstone/RedstoneManager.java
+++ b/src/main/java/com/hrznstudio/titanium/block/redstone/RedstoneManager.java
@@ -58,6 +58,7 @@ public class RedstoneManager<T extends IEnumValues<T> & IRedstoneAction> impleme
         CompoundTag value = new CompoundTag();
         value.putString("Name", action.getName());
         value.putBoolean("LastState", lastRedstoneState);
+        value.putBoolean("ShouldWork", shouldWork);
         return value;
     }
 
@@ -65,6 +66,7 @@ public class RedstoneManager<T extends IEnumValues<T> & IRedstoneAction> impleme
     public void deserializeNBT(HolderLookup.Provider provider, CompoundTag nbt) {
         this.action = this.action.getValue(nbt.getString("Name"));
         this.lastRedstoneState = nbt.getBoolean("LastState");
+        this.shouldWork = nbt.getBoolean("ShouldWork");
     }
 
 }

--- a/src/main/java/com/hrznstudio/titanium/block/tile/ActiveTile.java
+++ b/src/main/java/com/hrznstudio/titanium/block/tile/ActiveTile.java
@@ -225,18 +225,14 @@ public abstract class ActiveTile<T extends ActiveTile<T>> extends BasicTile<T> i
         if (level.getGameTime() % getFacingHandlerWorkTime() == 0) {
             if (multiInventoryComponent != null) {
                 for (InventoryComponent<T> inventoryHandler : multiInventoryComponent.getInventoryHandlers()) {
-                    if (inventoryHandler instanceof IFacingComponent) {
-                        if (((IFacingComponent) inventoryHandler).work(this.level, this.worldPosition, this.getFacingDirection(), getFacingHandlerWorkAmount()))
-                            break;
-                    }
+                    if (inventoryHandler instanceof IFacingComponent)
+                        ((IFacingComponent) inventoryHandler).work(this.level, this.worldPosition, this.getFacingDirection(), getFacingHandlerWorkAmount());
                 }
             }
             if (multiTankComponent != null) {
                 for (FluidTankComponent<T> tank : multiTankComponent.getTanks()) {
-                    if (tank instanceof IFacingComponent) {
-                        if (((IFacingComponent) tank).work(this.level, this.worldPosition, this.getFacingDirection(), getFacingHandlerWorkAmount()))
-                            break;
-                    }
+                    if (tank instanceof IFacingComponent)
+                        ((IFacingComponent) tank).work(this.level, this.worldPosition, this.getFacingDirection(), getFacingHandlerWorkAmount());
                 }
             }
         }

--- a/src/main/java/com/hrznstudio/titanium/component/inventory/MultiInventoryComponent.java
+++ b/src/main/java/com/hrznstudio/titanium/component/inventory/MultiInventoryComponent.java
@@ -138,8 +138,9 @@ public class MultiInventoryComponent<T extends IComponentHarness> implements ISc
         public ItemStack insertItem(int slot, @Nonnull ItemStack stack, boolean simulate) {
             InventoryComponent<T> handler = getFromSlot(slot);
             if (handler != null) {
-                if (handler.getInsertPredicate().test(stack, slot)) {
-                    return handler.insertItem(getRelativeSlot(handler, slot), stack, simulate);
+                int relativeSlot = getRelativeSlot(handler, slot);
+                if (handler.getInsertPredicate().test(stack, relativeSlot)) {
+                    return handler.insertItem(relativeSlot, stack, simulate);
                 } else {
                     return stack;
                 }


### PR DESCRIPTION
This PR will resolve issues mentioned in PR to Industrial Foregoing 😄

### Changes
- RedstoneManager will now also save ShouldWork state to NBT. This will prevent machines to work once on the world load before ShouldWork state is updated back to false.
- ActiveTile's IFacingComponents will now all execute in a single work tick, instead of stopping on the first sucesssfull insertion.
- SidedInventoryComponent will now try to push all extracted items, instead of giving up on the first slot and trying in the next tick.
- SidedInventoryComponent will now correctly validate slots based on the stack limit (Math.min(SlotLimit, StackLimit), preventing situations where it's stuck at trying to push into a single full slot.
- MultiInventoryComponent now provides correct slot indexes to the wrapped inventories on the item insertion check. 