### PR TITLE
Remove unused java.awt.* import.

### DIFF
--- a/src/main/java/com/hrznstudio/titanium/client/screen/addon/FacingHandlerScreenAddon.java
+++ b/src/main/java/com/hrznstudio/titanium/client/screen/addon/FacingHandlerScreenAddon.java
@@ -38,7 +38,8 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 
-import java.awt.*;
+import java.awt.Point;
+import java.awt.Rectangle;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;

--- a/src/main/java/com/hrznstudio/titanium/client/screen/addon/TankScreenAddon.java
+++ b/src/main/java/com/hrznstudio/titanium/client/screen/addon/TankScreenAddon.java
@@ -41,7 +41,9 @@ import net.neoforged.neoforge.fluids.FluidStack;
 import net.neoforged.neoforge.fluids.FluidType;
 import net.neoforged.neoforge.fluids.IFluidTank;
 import net.neoforged.neoforge.fluids.capability.IFluidHandler;
-import java.awt.*;
+
+import java.awt.Color;
+import java.awt.Rectangle;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/com/hrznstudio/titanium/component/fluid/SidedFluidTankComponent.java
+++ b/src/main/java/com/hrznstudio/titanium/component/fluid/SidedFluidTankComponent.java
@@ -31,7 +31,8 @@ import net.neoforged.neoforge.fluids.FluidStack;
 import net.neoforged.neoforge.fluids.capability.IFluidHandler;
 import net.neoforged.neoforge.fluids.capability.templates.FluidTank;
 
-import java.awt.*;
+import java.awt.Color;
+import java.awt.Rectangle;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;


### PR DESCRIPTION
There are a few name ambiguities because importing `java.awt.*` bring in `java.awt.List` which shadows `java.util.List`.